### PR TITLE
migrar envío de correos de Gmail SMTP a Mailjet API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
             <version>0.31.0</version>
         </dependency> -->
 
+		<dependency>
+			<groupId>com.mailjet</groupId>
+			<artifactId>mailjet-client</artifactId>
+			<version>5.2.4</version>
+		</dependency>
 
     </dependencies>
 

--- a/src/main/java/net/brubio/config/MailjetConfig.java
+++ b/src/main/java/net/brubio/config/MailjetConfig.java
@@ -1,0 +1,22 @@
+package net.brubio.config;
+
+import net.brubio.model.MailjetJavaMailSender;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+public class MailjetConfig {
+
+    @Value("${MAILJET_API_KEY}")
+    private String apiKey;
+
+    @Value("${MAILJET_SECRET_KEY}")
+    private String secretKey;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return new MailjetJavaMailSender(apiKey, secretKey);
+    }
+}

--- a/src/main/java/net/brubio/model/MailjetJavaMailSender.java
+++ b/src/main/java/net/brubio/model/MailjetJavaMailSender.java
@@ -1,0 +1,76 @@
+package net.brubio.model;
+
+import com.mailjet.client.ClientOptions;
+import com.mailjet.client.MailjetClient;
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.MailjetResponse;
+import com.mailjet.client.resource.Emailv31;
+import jakarta.mail.internet.MimeMessage;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+
+import java.io.InputStream;
+
+public class MailjetJavaMailSender implements JavaMailSender {
+
+    private final String apiKey;
+    private final String secretKey;
+
+    public MailjetJavaMailSender(String apiKey, String secretKey) {
+        this.apiKey = apiKey;
+        this.secretKey = secretKey;
+    }
+
+    @Value("${MAILJET_SENDER_EMAIL}")
+    private String senderEmail;
+
+    @Override
+    public void send(SimpleMailMessage message) {
+        try {
+            MailjetClient client = new MailjetClient(apiKey, secretKey);
+            System.err.println(senderEmail);
+            //String senderEmail = System.getenv("MAILJET_SENDER_EMAIL");
+            if (senderEmail == null || senderEmail.isEmpty()) {
+                throw new IllegalStateException("MAILJET_SENDER_EMAIL no está definida en el entorno.");
+            }
+//            String senderEmail = "bryamrubio312@gmail.com";
+//            if (senderEmail == null || senderEmail.isEmpty()) {
+//                throw new IllegalStateException("MAILJET_SENDER_EMAIL no está definida en el entorno.");
+//            }
+            MailjetRequest request = new MailjetRequest(Emailv31.resource)
+                    .property(Emailv31.MESSAGES, new JSONArray()
+                            .put(new JSONObject()
+                                    .put(Emailv31.Message.FROM, new JSONObject()
+                                            .put("Email", senderEmail)
+                                            .put("Name", "EmpleosApp"))
+                                    .put(Emailv31.Message.TO, new JSONArray()
+                                            .put(new JSONObject()
+                                                    .put("Email", message.getTo()[0])
+                                                    .put("Name", "Usuario")))
+                                    .put(Emailv31.Message.SUBJECT, message.getSubject())
+                                    .put(Emailv31.Message.TEXTPART, message.getText())
+                            ));
+
+            MailjetResponse response = client.post(request);
+            System.out.println("Estado: " + response.getStatus());
+            System.out.println("Respuesta: " + response.getData());
+        } catch (Exception e) {
+            throw new MailSendException("Error al enviar correo con Mailjet", e);
+        }
+    }
+
+    // Métodos no usados, puedes dejarlos vacíos
+    @Override public void send(SimpleMailMessage... messages) {}
+    @Override public void send(MimeMessage mimeMessage) {}
+    @Override public void send(MimeMessage... mimeMessages) {}
+    @Override public void send(MimeMessagePreparator mimeMessagePreparator) {}
+    @Override public void send(MimeMessagePreparator... mimeMessagePreparators) {}
+    @Override public MimeMessage createMimeMessage() { return null; }
+    @Override public MimeMessage createMimeMessage(InputStream contentStream) { return null; }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,16 +31,20 @@ spring.data.web.pageable.default-page-size=5
 #spring.security.user.name=brubio
 #spring.security.user.password=masterkey
 
-spring.mail.host=smtp.gmail.com
+# spring.mail.host=smtp.gmail.com
 # spring.mail.port=587
-spring.mail.port=465
-spring.mail.username=${MAIL_USERNAME}
-spring.mail.password=${MAIL_PASSWORD}
-spring.mail.properties.mail.smtp.auth=true
+#spring.mail.port= 465
+#spring.mail.username=${MAIL_USERNAME}
+#spring.mail.password=${MAIL_PASSWORD}
+#spring.mail.properties.mail.smtp.auth=true
 # spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
-spring.main.allow-circular-references=true
-spring.mail.properties.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+#spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+#spring.main.allow-circular-references=true
+#spring.mail.properties.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+
+MAILJET_API_KEY=${MAIL_JET_API_KEY}
+MAILJET_SECRET_KEY=${MAIL_JET_SECRET_KEY}
+MAILJET_SENDER_EMAIL=${MAIL_JET_EMAIL}
 
 spring.datasource.hikari.maximum-pool-size=2
 spring.datasource.hikari.minimum-idle=1


### PR DESCRIPTION

1. Se creó una clase personalizada MailjetJavaMailSender que utiliza el cliente oficial de Mailjet (MailjetClient) y la estructura Emailv31 para construir y enviar correos vía API.
2. Se agregó una clase de configuración (MailjetMailSenderConfiguration) que registra MailjetJavaMailSender como el bean principal de tipo JavaMailSender, reemplazando la implementación SMTP por defecto.
3. Se parametrizó el remitente (FROM) usando una variable de entorno para mantener flexibilidad y seguridad en entornos como Render.
4. Se eliminaron las dependencias y configuraciones relacionadas con Gmail SMTP (spring.mail.host, spring.mail.port, etc.) en el archivo properties.